### PR TITLE
feat: add prop type to modal

### DIFF
--- a/src/features/boards/components/CreateBoardModal.js
+++ b/src/features/boards/components/CreateBoardModal.js
@@ -1,5 +1,7 @@
 import { Button, Modal } from 'antd';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
 import { BoardForm, StyledInput } from '../styles';
 
 import { DEFAULT_COLOR } from '../../../core/constants';
@@ -60,3 +62,9 @@ export class CreateBoardModal extends Component {
         );
     }
 }
+
+CreateBoardModal.propTypes = {
+    onCloseModal: PropTypes.func,
+    onCreateBoard: PropTypes.func,
+    visible: PropTypes.bool
+};


### PR DESCRIPTION
### Description

The PR adds prop types to modal. Closes https://github.com/bmarvinb/react-trello-clone/issues/137

### How to Test?
1. Change the `line 69` in the `CreateModal.js` file to `PropTypes.string` 
2. Run the app ad login and click on the Create Board card
3. Inspect in google chrome console, there should be warning saying `expected string...` which is expected as we are sending boolean.
![image](https://user-images.githubusercontent.com/15359575/135753206-07372d4e-9c0a-4e5b-b060-e1842c4d3033.png)
